### PR TITLE
include parsedPem type when unrecognized

### DIFF
--- a/src/main/java/com/spotify/sshagenttls/CertKey.java
+++ b/src/main/java/com/spotify/sshagenttls/CertKey.java
@@ -74,7 +74,7 @@ public abstract class CertKey {
     } else if (parsedPem instanceof PrivateKeyInfo) {
       keyInfo = (PrivateKeyInfo) parsedPem;
     } else {
-      throw new UnsupportedOperationException("Unable to parse X.509 certificate.");
+      throw new UnsupportedOperationException("Unable to parse X.509 certificate, received " + parsedPem.getClass());
     }
 
     final PKCS8EncodedKeySpec spec = new PKCS8EncodedKeySpec(keyInfo.getEncoded());


### PR DESCRIPTION
If throwing an exception when the `parsedPem` is not an instance of PEMKeyPair or PrivateKeyInfo, we should include the type in the exception message to make debugging easier.